### PR TITLE
Make block comments non-greedy

### DIFF
--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -25,7 +25,7 @@ match {
 	// Skip whitespace and comments
 	r"\s*" => { },
 	r"//[^\n\r]*[\n\r]*" => { }, // `// comment`
-	r"/\*([^\*]*\*+[^\*/])*([^\*]*\*+|[^\*])*\*/" => { }, // `/* comment */`
+	r"/\*([^*]|\*[^/])*\*/" => { }, // `/* comment */`
 }
 
 pub File = { <Root*> }


### PR DESCRIPTION
Prevent the regex from matching `*/` within a block comment, so they can't "leak" from one to the next one.

Fixes #13